### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/protobuf-2.0.3/python/setup.py
+++ b/protobuf-2.0.3/python/setup.py
@@ -36,7 +36,7 @@ def generate_proto(source):
        os.path.getmtime(source) > os.path.getmtime(output))):
     print "Generating %s..." % output
 
-    if protoc == None:
+    if protoc is None:
       sys.stderr.write(
           "protoc is not installed nor found in ../src.  Please compile it "
           "or install the binary package.\n")

--- a/protobuf-2.1.0/python/setup.py
+++ b/protobuf-2.1.0/python/setup.py
@@ -39,7 +39,7 @@ def generate_proto(source):
        os.path.getmtime(source) > os.path.getmtime(output))):
     print "Generating %s..." % output
 
-    if protoc == None:
+    if protoc is None:
       sys.stderr.write(
           "protoc is not installed nor found in ../src.  Please compile it "
           "or install the binary package.\n")

--- a/protobuf-2.2.0/python/setup.py
+++ b/protobuf-2.2.0/python/setup.py
@@ -39,7 +39,7 @@ def generate_proto(source):
        os.path.getmtime(source) > os.path.getmtime(output))):
     print "Generating %s..." % output
 
-    if protoc == None:
+    if protoc is None:
       sys.stderr.write(
           "protoc is not installed nor found in ../src.  Please compile it "
           "or install the binary package.\n")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:metasyntactic?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:metasyntactic?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
