### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/protobuf-2.0.3/python/mox.py
+++ b/protobuf-2.0.3/python/mox.py
@@ -1029,8 +1029,8 @@ class SameElementsAs(Comparator):
     """
 
     try:
-      expected = dict([(element, None) for element in self._expected_seq])
-      actual = dict([(element, None) for element in actual_seq])
+      expected = {element: None for element in self._expected_seq}
+      actual = {element: None for element in actual_seq}
     except TypeError:
       # Fall back to slower list-compare if any of the objects are unhashable.
       expected = list(self._expected_seq)

--- a/protobuf-2.1.0/python/mox.py
+++ b/protobuf-2.1.0/python/mox.py
@@ -1029,8 +1029,8 @@ class SameElementsAs(Comparator):
     """
 
     try:
-      expected = dict([(element, None) for element in self._expected_seq])
-      actual = dict([(element, None) for element in actual_seq])
+      expected = {element: None for element in self._expected_seq}
+      actual = {element: None for element in actual_seq}
     except TypeError:
       # Fall back to slower list-compare if any of the objects are unhashable.
       expected = list(self._expected_seq)

--- a/protobuf-2.2.0/python/mox.py
+++ b/protobuf-2.2.0/python/mox.py
@@ -1029,8 +1029,8 @@ class SameElementsAs(Comparator):
     """
 
     try:
-      expected = dict([(element, None) for element in self._expected_seq])
-      actual = dict([(element, None) for element in actual_seq])
+      expected = {element: None for element in self._expected_seq}
+      actual = {element: None for element in actual_seq}
     except TypeError:
       # Fall back to slower list-compare if any of the objects are unhashable.
       expected = list(self._expected_seq)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:metasyntactic?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:metasyntactic?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
